### PR TITLE
Agregando a documentacion el icono deenlace externo

### DIFF
--- a/docs/src/views/IconografiaView.vue
+++ b/docs/src/views/IconografiaView.vue
@@ -174,6 +174,10 @@
         <span>icono-eliminar</span>
       </div>
       <div>
+        <span class="icono-enlace-externo"></span>
+        <span>icono-enlace-externo</span>
+      </div>
+      <div>
         <span class="icono-enlace-subrayado"></span>
         <span>icono-enlace-subrayado</span>
       </div>


### PR DESCRIPTION
Esto es solo edicion de la documentación, no de la librería de estilos en sí. Se añadió en la documentación el icono-enlace-externo, para que lxs devs sepan como se usa este ícono que viene desde el fontastic. Si no logras visualizarlo, quizá sea problema del caché 
<img width="155" alt="Captura de Pantalla 2023-03-21 a la(s) 12 24 00" src="https://user-images.githubusercontent.com/48138542/226706632-526e0487-0373-4d6b-9f9c-d65692164856.png">
