### PR TITLE
se quita la base /sisdaicss/ para poder desplegar en desarrollo

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",
-    "build": "vite build --base=/sisdaicss/",
+    "build": "vite build",
     "preview": "vite preview --port 4173",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore"
   },


### PR DESCRIPTION
Se quitó del archivo /docs/package.json la instrucción "vite build --base=/sisdaicss/" y se dejó solamente "vite build" para poder hacer el despliegue desde infraestructura.